### PR TITLE
Progress Callback

### DIFF
--- a/packages/sync-stack/src/read/indexer/filterLogs.ts
+++ b/packages/sync-stack/src/read/indexer/filterLogs.ts
@@ -1,12 +1,12 @@
 import { EventEmitter } from "events";
 import { StorageAdapterBlock } from "@latticexyz/store-sync";
 import { ReaderFilterIndexerParams, Reader } from "../../types";
-import { isStorageAdapterBlock, processJSONStream } from "../../utils/common";
+import { isStorageAdapterBlockIndexer, processJSONStream } from "../../utils/common";
 
 export const filterLogs = (args: ReaderFilterIndexerParams): Reader => {
   const { indexerUrl, filter } = args;
   return {
-    subscribe: (userCallback: (block: StorageAdapterBlock) => void) => {
+    subscribe: (userCallback) => {
       const eventEmitter = new EventEmitter();
 
       // Listen for the 'update' event
@@ -18,17 +18,19 @@ export const filterLogs = (args: ReaderFilterIndexerParams): Reader => {
           const urlEncodedQuery = encodeURIComponent(JSON.stringify(filter));
           const url = `${indexerUrl}/api/logs?input=${urlEncodedQuery}`;
           for await (const result of processJSONStream(url)) {
-            if (!isStorageAdapterBlock(result)) {
+            if (!isStorageAdapterBlockIndexer(result)) {
               eventEmitter.emit("update", {
                 blockNumber: 0n,
                 logs: [],
+                progress: 1,
               } as StorageAdapterBlock);
               return;
             }
 
             eventEmitter.emit("update", {
-              ...result,
               blockNumber: BigInt(result.blockNumber),
+              logs: result.logs,
+              progress: result.chunk / result.totalChunks,
             });
           }
         } catch (error) {

--- a/packages/sync-stack/src/sync/factories/customSync.ts
+++ b/packages/sync-stack/src/sync/factories/customSync.ts
@@ -5,22 +5,20 @@ export function createSync(options: SyncOptions): Sync {
   const unsubscribe: (() => void)[] = [];
 
   const sync: Sync = {
-    start: () => {
-      function subToReader(reader: Reader) {
+    start: (onProgress) => {
+      function subToReader(reader: Reader, index: number) {
+        onProgress && onProgress(index, 0n, 0);
         unsubscribe.push(
           reader.subscribe((block) => {
+            onProgress && onProgress(index, block.blockNumber, block.progress ?? 1);
             for (const log of block.logs) {
-              Array.isArray(writer)
-                ? writer.forEach((write) => write(log))
-                : writer(log);
+              Array.isArray(writer) ? writer.forEach((write) => write(log)) : writer(log);
             }
           })
         );
       }
 
-      Array.isArray(reader)
-        ? reader.forEach((read) => subToReader(read))
-        : subToReader(reader);
+      Array.isArray(reader) ? reader.forEach((read, index) => subToReader(read, index)) : subToReader(reader, 0);
     },
 
     unsubscribe: () => {

--- a/packages/sync-stack/src/sync/factories/recsSync.ts
+++ b/packages/sync-stack/src/sync/factories/recsSync.ts
@@ -3,14 +3,13 @@ import { createSync } from "./customSync";
 import { Write } from "../../write";
 import {
   ReaderFilterIndexerParams,
+  ReaderFilterRpcParams,
   ReaderQueryDecodedIndexerParams,
   ReaderSubscribeRpcParams,
   WriterRecsParams,
 } from "../../types";
 
-export function liveRPCRecsSync(
-  args: ReaderSubscribeRpcParams & WriterRecsParams
-) {
+export function liveRPCRecsSync(args: ReaderSubscribeRpcParams & WriterRecsParams) {
   const { world, tables, address, logFilter, publicClient } = args;
 
   return createSync({
@@ -23,9 +22,24 @@ export function liveRPCRecsSync(
   });
 }
 
-export function filterIndexerRecsSync(
-  args: WriterRecsParams & ReaderFilterIndexerParams
-) {
+export function RPCRecsSync(args: ReaderFilterRpcParams & WriterRecsParams) {
+  const { world, tables, address, filter, publicClient, fromBlock, toBlock, maxBlockRange, maxRetryCount } = args;
+
+  return createSync({
+    reader: Read.fromRPC.filter({
+      address: address,
+      publicClient: publicClient,
+      filter,
+      fromBlock,
+      toBlock,
+      maxBlockRange,
+      maxRetryCount,
+    }),
+    writer: Write.toRecs({ world, tables }),
+  });
+}
+
+export function filterIndexerRecsSync(args: WriterRecsParams & ReaderFilterIndexerParams) {
   const { world, tables, filter, indexerUrl } = args;
 
   return createSync({
@@ -37,9 +51,7 @@ export function filterIndexerRecsSync(
   });
 }
 
-export const queryDecodedIndexerRecsSync = (
-  args: WriterRecsParams & ReaderQueryDecodedIndexerParams
-) => {
+export const queryDecodedIndexerRecsSync = (args: WriterRecsParams & ReaderQueryDecodedIndexerParams) => {
   const { world, tables, indexerUrl, query } = args;
 
   return createSync({

--- a/packages/sync-stack/src/sync/index.ts
+++ b/packages/sync-stack/src/sync/index.ts
@@ -3,6 +3,7 @@ import * as sync from "./factories";
 export const Sync = {
   withCustom: sync.createSync,
   withLiveRPCRecsSync: sync.liveRPCRecsSync,
+  withRPCRecsSync: sync.RPCRecsSync,
   withFilterIndexerRecsSync: sync.filterIndexerRecsSync,
   withQueryDecodedIndexerRecsSync: sync.queryDecodedIndexerRecsSync,
 };

--- a/packages/sync-stack/src/types.ts
+++ b/packages/sync-stack/src/types.ts
@@ -13,10 +13,7 @@ export type DecodedIndexerQuery = z.input<typeof dbQuerySchema>;
 
 export type LogFilter = z.input<typeof filterSchema>;
 
-export type FetchAndFilterLogsOptions = Omit<
-  FetchLogsOptions<StoreEventsAbi>,
-  "events"
-> & {
+export type FetchAndFilterLogsOptions = Omit<FetchLogsOptions<StoreEventsAbi>, "events"> & {
   logFilter?: LogFilter["filters"];
 };
 
@@ -27,7 +24,7 @@ export type ReaderSubscribeRpcParams = {
 };
 
 export type Reader = {
-  subscribe: (callback: (block: StorageAdapterBlock) => void) => () => void;
+  subscribe: (callback: (block: StorageAdapterBlock & { progress?: number }) => void) => () => void;
 };
 
 export type ReaderFilterIndexerParams = {
@@ -40,10 +37,7 @@ export type ReaderQueryDecodedIndexerParams = {
   query: DecodedIndexerQuery;
 };
 
-export type ReaderFilterRpcParams = Omit<
-  FetchLogsOptions<StoreEventsAbi>,
-  "events"
-> & {
+export type ReaderFilterRpcParams = Omit<FetchLogsOptions<StoreEventsAbi>, "events"> & {
   filter?: LogFilter;
 };
 
@@ -56,15 +50,9 @@ export type WriterRecsParams = {
 
 export type WriterAdapterFunctions = {
   set: (log: StorageAdapterLog & { eventName: "Store_SetRecord" }) => void;
-  updateStatic: (
-    log: StorageAdapterLog & { eventName: "Store_SpliceStaticData" }
-  ) => void;
-  updateDynamic: (
-    log: StorageAdapterLog & { eventName: "Store_SpliceDynamicData" }
-  ) => void;
-  delete: (
-    log: StorageAdapterLog & { eventName: "Store_DeleteRecord" }
-  ) => void;
+  updateStatic: (log: StorageAdapterLog & { eventName: "Store_SpliceStaticData" }) => void;
+  updateDynamic: (log: StorageAdapterLog & { eventName: "Store_SpliceDynamicData" }) => void;
+  delete: (log: StorageAdapterLog & { eventName: "Store_DeleteRecord" }) => void;
 };
 
 export type SyncOptions = {
@@ -73,6 +61,6 @@ export type SyncOptions = {
 };
 
 export type Sync = {
-  start: () => void;
+  start: (onProgress?: (index: number, blockNumber: bigint, progress: number) => void) => void;
   unsubscribe: () => void;
 };

--- a/packages/sync-stack/src/utils/common.ts
+++ b/packages/sync-stack/src/utils/common.ts
@@ -8,6 +8,19 @@ export function isStorageAdapterBlock(
   return data && typeof data.blockNumber === "string" && Array.isArray(data.logs);
 }
 
+export function isStorageAdapterBlockIndexer(
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  data: any
+): data is Omit<StorageAdapterBlock, "blockNumber"> & { blockNumber: string; chunk: number; totalChunks: number } {
+  return (
+    data &&
+    typeof data.blockNumber === "string" &&
+    Array.isArray(data.logs) &&
+    typeof data.chunk === "number" &&
+    typeof data.totalChunks === "number"
+  );
+}
+
 export const createLogFilter =
   (filters: NonNullable<LogFilter["filters"]>) =>
   (log: StoreEventsLog): boolean =>


### PR DESCRIPTION
This PR adds a callback on the sync start function that returns the progress % and block number and index of writer (if you have multiple writers). Also added is `withRPCRecsSync` sync helper which fetches and syncs blocks from rpc given a range:

For example:
```ts
// create recs world and components
const world = createWorld();
const tables = resolveConfig(config).tables;
recsStorage({
  world,
  tables,
});

const publicClient = createPublicClient({
  transport: http(),
  chain: localhost,
});

// sync recs from query results whre score is greater than 100k
const sync = Sync.withRPCRecsSync({
  world,
  tables,
  address: WORLD_ADDRESS,
  publicClient,
  fromBlock: 500n,
  toBlock: 5000n,
});

//start the sync
sync.start((index, blockNumber, progress) => {
  console.log(blockNumber, progress);
});
```