### PR TITLE
Add on condition in include clause

### DIFF
--- a/packages/pg-indexer-reader/src/postgres/querySchema.ts
+++ b/packages/pg-indexer-reader/src/postgres/querySchema.ts
@@ -18,6 +18,7 @@ const includeClauseSchema = z.array(
   z.object({
     tableName: z.string(),
     tableType: z.enum(["offchainTable", "table"]).default("table"),
+    on: z.string().default("__key_bytes"),
   })
 );
 

--- a/packages/pg-indexer-reader/src/postgres/queryToSql.ts
+++ b/packages/pg-indexer-reader/src/postgres/queryToSql.ts
@@ -129,15 +129,17 @@ export function toSQL(sql: Sql, address: string, query: Query[]): PendingQuery<R
         SELECT __key_bytes, table_id FROM base
 
       `,
-          ...include.map(({ tableName, tableType }) => {
+          ...include.map(({ tableName, tableType, on }) => {
             const dbTableName = snakeCase(tableName);
             const tableId = tableNameToId(tableName, tableType);
 
             return sql`
-            SELECT base.__key_bytes, ${convertIfHexOtherwiseReturnString(tableId)} as table_id
-            FROM base JOIN ${sql(schema)}.${sql(dbTableName)} ON ${sql(schema)}.${sql(
-              dbTableName
-            )}.__key_bytes = base.__key_bytes`;
+            SELECT ${sql(schema)}.${sql(dbTableName)}.__key_bytes, ${convertIfHexOtherwiseReturnString(
+              tableId
+            )} as table_id
+            FROM base JOIN ${sql(schema)}.${sql(dbTableName)} ON ${sql(schema)}.${sql(dbTableName)}.${sql(
+              on
+            )} = base.__key_bytes`;
           }),
         ]);
       }

--- a/packages/sync-stack/examples/read/decoded-indexer/queryTableWithConditions.ts
+++ b/packages/sync-stack/examples/read/decoded-indexer/queryTableWithConditions.ts
@@ -7,17 +7,16 @@ const reader = Read.fromDecodedIndexer.query({
     address: WORLD_ADDRESS,
     queries: [
       {
-        tableName: "Score",
-        and: [
+        tableName: "Position",
+        where: {
+          column: "__key_bytes",
+          operation: "eq",
+          value: "0x83dd2fd6d9f822f4af640fef65513792462aedae397fa81159452ccc35327d0e",
+        },
+        include: [
           {
-            column: "value",
-            operation: "gt",
-            value: 50_000_000n,
-          },
-          {
-            column: "value",
-            operation: "lte",
-            value: 100_000_000n,
+            tableName: "OwnedBy",
+            on: "entity",
           },
         ],
       },
@@ -26,5 +25,5 @@ const reader = Read.fromDecodedIndexer.query({
 });
 
 reader.subscribe((logs) => {
-  console.log(logs);
+  console.log(logs.logs);
 });

--- a/packages/sync-stack/src/utils/schema.ts
+++ b/packages/sync-stack/src/utils/schema.ts
@@ -5,6 +5,7 @@ const includeClauseSchema = z.array(
   z.object({
     tableName: z.string(),
     tableType: z.enum(["offchainTable", "table"]).default("table"),
+    on: z.string().default("__key_bytes"),
   })
 );
 


### PR DESCRIPTION
This PR adds the ability to choose an alternative column to match related records. By default, include will match `key_bytes` to `key_bytes`. Now you can specify another column to use from the included table to match to `key_bytes`, specifically useful if included table key_bytes is constructed from multiple keys.

Example:

```ts
const reader = Read.fromDecodedIndexer.query({
  indexerUrl: INDEXER_URL,
  query: {
    address: WORLD_ADDRESS,
    queries: [
      {
        tableName: "Position",
        where: {
          column: "__key_bytes",
          operation: "eq",
          value: "0x83dd2fd6d9f822f4af640fef65513792462aedae397fa81159452ccc35327d0e",
        },
        include: [
          {
            tableName: "QueueItemUnits",
            on: "entity",
          },
        ],
      },
    ],
  },
});
```

We are getting position entites, and including QueueItemUnits records where its `entity` matches the returned `key_bytes` from the position query.