### PR TITLE
Revert Debug imports for build

### DIFF
--- a/packages/sync-stack/src/utils/debug.ts
+++ b/packages/sync-stack/src/utils/debug.ts
@@ -1,7 +1,7 @@
-import { debug as parentDebug } from "debug";
+import createDebug from "debug";
 
-export const debug = parentDebug("primodium:sync-stack");
-export const error = parentDebug("primodium:sync-stack");
+export const debug = createDebug("primodium:sync-stack");
+export const error = createDebug("primodium:sync-stack");
 
 // Pipe debug output to stdout instead of stderr
 debug.log = console.debug.bind(console);


### PR DESCRIPTION
New imports were causing build issues. Reverting to previous import structure.