### PR TITLE
Fix indexer schema and upgrade dependencies

### DIFF
--- a/packages/pg-indexer-reader/docker-compose.local.yml
+++ b/packages/pg-indexer-reader/docker-compose.local.yml
@@ -16,7 +16,7 @@ services:
       - /var/lib/postgresql/data
 
   primodium-postgres-index-write:
-    image: ghcr.io/latticexyz/store-indexer:sha-735d957
+    image: ghcr.io/latticexyz/store-indexer:sha-338c8e5
     restart: always
     platform: linux/amd64
     networks:

--- a/packages/pg-indexer-reader/package.json
+++ b/packages/pg-indexer-reader/package.json
@@ -36,9 +36,9 @@
   "dependencies": {
     "@koa/cors": "^4.0.0",
     "@koa/router": "^12.0.1",
-    "@latticexyz/common": "2.0.0-main-d3f0d32f",
-    "@latticexyz/protocol-parser": "2.0.0-main-d3f0d32f",
-    "@latticexyz/store-sync": "2.0.0-main-d3f0d32f",
+    "@latticexyz/common": "2.0.9",
+    "@latticexyz/protocol-parser": "2.0.9",
+    "@latticexyz/store-sync": "2.0.9",
     "accepts": "^1.3.8",
     "change-case": "^5.3.0",
     "debug": "^4.3.4",
@@ -47,7 +47,7 @@
     "koa-compose": "^4.1.0",
     "postgres": "3.3.5",
     "superjson": "^1.12.4",
-    "viem": "1.14.0",
+    "viem": "2.9.20",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/packages/pg-indexer-reader/src/postgres/queryLogs.ts
+++ b/packages/pg-indexer-reader/src/postgres/queryLogs.ts
@@ -2,7 +2,6 @@ import { isNotNull } from "@latticexyz/common/utils";
 import { PendingQuery, Row, Sql } from "postgres";
 import { hexToBytes } from "viem";
 import { z } from "zod";
-import { input } from "@latticexyz/store-sync/indexer-client";
 import { transformSchemaName } from "@latticexyz/store-sync/postgres";
 import { Record } from "../util/common";
 import { filterSchema } from "./querySchema";

--- a/packages/pg-indexer-reader/src/postgres/routes/api.ts
+++ b/packages/pg-indexer-reader/src/postgres/routes/api.ts
@@ -23,6 +23,7 @@ export function api(database: Sql): Middleware {
     } catch (e) {
       ctx.status = 400;
       ctx.body = JSON.stringify(e);
+      ctx.set("Content-Type", "application/json");
       debug(e);
       return;
     }
@@ -66,7 +67,7 @@ export function api(database: Sql): Middleware {
                 chunk: index + 1,
                 totalChunks: chunks.length,
                 logs: chunk,
-              }) + "\n"
+              }) + "\n",
             );
           });
 
@@ -78,6 +79,7 @@ export function api(database: Sql): Middleware {
       ctx.status = 200;
     } catch (e) {
       ctx.status = 500;
+      ctx.set("Content-Type", "application/json");
       ctx.body = JSON.stringify(e);
       error(e);
     }
@@ -127,7 +129,7 @@ export function api(database: Sql): Middleware {
                 chunk: index + 1,
                 totalChunks: chunks.length,
                 logs: chunk,
-              }) + "\n"
+              }) + "\n",
             );
           });
 

--- a/packages/pg-indexer-reader/src/util/recordToLog.ts
+++ b/packages/pg-indexer-reader/src/util/recordToLog.ts
@@ -1,9 +1,9 @@
 import { StorageAdapterLog } from "@latticexyz/store-sync";
-import { decodeDynamicField } from "@latticexyz/protocol-parser";
+import { decodeDynamicField } from "@latticexyz/protocol-parser/internal";
 import { RecordData } from "./common";
 
 export function recordToLog(
-  record: Omit<RecordData, "recordBlockNumber">
+  record: Omit<RecordData, "recordBlockNumber">,
 ): StorageAdapterLog & { eventName: "Store_SetRecord" } {
   return {
     address: record.address,

--- a/packages/sync-stack/package.json
+++ b/packages/sync-stack/package.json
@@ -26,12 +26,12 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@latticexyz/block-logs-stream": "2.0.6",
-    "@latticexyz/common": "2.0.6",
-    "@latticexyz/protocol-parser": "2.0.6",
-    "@latticexyz/recs": "2.0.6",
-    "@latticexyz/schema-type": "2.0.6",
-    "@latticexyz/store": "2.0.6",
+    "@latticexyz/block-logs-stream": "2.0.9",
+    "@latticexyz/common": "2.0.9",
+    "@latticexyz/protocol-parser": "2.0.9",
+    "@latticexyz/recs": "2.0.9",
+    "@latticexyz/schema-type": "2.0.9",
+    "@latticexyz/store": "2.0.9",
     "debug": "^4.3.4",
     "eventemitter3": "^5.0.1",
     "viem": "2.9.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,23 +124,23 @@ importers:
   packages/sync-stack:
     dependencies:
       '@latticexyz/block-logs-stream':
-        specifier: 2.0.6
-        version: 2.0.6(typescript@5.1.6)(zod@3.22.4)
+        specifier: 2.0.9
+        version: 2.0.9(typescript@5.1.6)(zod@3.22.4)
       '@latticexyz/common':
-        specifier: 2.0.6
-        version: 2.0.6(typescript@5.1.6)(zod@3.22.4)
+        specifier: 2.0.9
+        version: 2.0.9(typescript@5.1.6)(zod@3.22.4)
       '@latticexyz/protocol-parser':
-        specifier: 2.0.6
-        version: 2.0.6(typescript@5.1.6)(zod@3.22.4)
+        specifier: 2.0.9
+        version: 2.0.9(typescript@5.1.6)(zod@3.22.4)
       '@latticexyz/recs':
-        specifier: 2.0.6
-        version: 2.0.6(typescript@5.1.6)(zod@3.22.4)
+        specifier: 2.0.9
+        version: 2.0.9(typescript@5.1.6)(zod@3.22.4)
       '@latticexyz/schema-type':
-        specifier: 2.0.6
-        version: 2.0.6(typescript@5.1.6)(zod@3.22.4)
+        specifier: 2.0.9
+        version: 2.0.9(typescript@5.1.6)(zod@3.22.4)
       '@latticexyz/store':
-        specifier: 2.0.6
-        version: 2.0.6(typescript@5.1.6)
+        specifier: 2.0.9
+        version: 2.0.9(typescript@5.1.6)
       debug:
         specifier: ^4.3.4
         version: 4.3.4
@@ -966,22 +966,6 @@ packages:
       - supports-color
     dev: false
 
-  /@latticexyz/block-logs-stream@2.0.6(typescript@5.1.6)(zod@3.22.4):
-    resolution: {integrity: sha512-kN0jNcVBrr9wblRnTFXnzQzSIG/151DAA1F1xv4+rA+yVjLgdgR3u51wKOwtPwjNPYyXWYULt3HBiCwkguUpfA==}
-    dependencies:
-      '@latticexyz/common': 2.0.6(typescript@5.1.6)(zod@3.22.4)
-      abitype: 1.0.0(typescript@5.1.6)(zod@3.22.4)
-      debug: 4.3.4
-      rxjs: 7.5.5
-      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - zod
-    dev: false
-
   /@latticexyz/block-logs-stream@2.0.9(typescript@5.1.6)(zod@3.22.4):
     resolution: {integrity: sha512-KCdrgrQ3Vsuwx1VHMHQO1JS/5UmtWxTWVw6LsKS6y6Oqy02v3Z2dZOfacZ9ZE4D59audWFz8BNZL1SW5j1PtPQ==}
     dependencies:
@@ -993,26 +977,6 @@ packages:
     transitivePeerDependencies:
       - '@aws-sdk/client-kms'
       - asn1.js
-      - bufferutil
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - zod
-    dev: false
-
-  /@latticexyz/common@2.0.6(typescript@5.1.6)(zod@3.22.4):
-    resolution: {integrity: sha512-9uXTYzWvhVyZ772pC2GuJ5gQsOv0iHkQNYZxUbQRv9okwnZ0tf0mqoOkaCDGnizcf5ubVxBmO+J4eLBT4g9I3Q==}
-    dependencies:
-      '@latticexyz/schema-type': 2.0.6(typescript@5.1.6)(zod@3.22.4)
-      '@solidity-parser/parser': 0.16.2
-      debug: 4.3.4
-      execa: 7.2.0
-      p-queue: 7.4.1
-      p-retry: 5.1.2
-      prettier: 3.2.5
-      prettier-plugin-solidity: 1.3.1(prettier@3.2.5)
-      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
-    transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
@@ -1048,23 +1012,6 @@ packages:
       - zod
     dev: false
 
-  /@latticexyz/config@2.0.6(typescript@5.1.6):
-    resolution: {integrity: sha512-Ch3aHEEjuZXy6oDTDNjGfxPw9gKzHOxGxunvbx3C+wjPtjkmB/GytjU7FRr5wnflGU20Upi4ASTH5WIDIini8w==}
-    dependencies:
-      '@latticexyz/common': 2.0.6(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/schema-type': 2.0.6(typescript@5.1.6)(zod@3.22.4)
-      esbuild: 0.17.19
-      find-up: 6.3.0
-      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
-      zod: 3.22.4
-      zod-validation-error: 1.5.0(zod@3.22.4)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - typescript
-      - utf-8-validate
-    dev: false
-
   /@latticexyz/config@2.0.9(typescript@5.1.6):
     resolution: {integrity: sha512-iKvGHmI5Fk8J/C6tffJx1vMWhfIy03+7dk1kr1aGBsTC4BDajDoWNjmlXFxPgYtq8BxreuHVaR0W089+4nrKlQ==}
     dependencies:
@@ -1082,22 +1029,6 @@ packages:
       - supports-color
       - typescript
       - utf-8-validate
-    dev: false
-
-  /@latticexyz/protocol-parser@2.0.6(typescript@5.1.6)(zod@3.22.4):
-    resolution: {integrity: sha512-HcxgBk+UpBufG0VTYSR02EzwfXhqtHnv4JL3Sn6XiGxCKuI90ZfwKscAhkOgR8NialQq/wG6Iipb53CIWsGO9Q==}
-    dependencies:
-      '@latticexyz/common': 2.0.6(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/config': 2.0.6(typescript@5.1.6)
-      '@latticexyz/schema-type': 2.0.6(typescript@5.1.6)(zod@3.22.4)
-      abitype: 1.0.0(typescript@5.1.6)(zod@3.22.4)
-      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - zod
     dev: false
 
   /@latticexyz/protocol-parser@2.0.9(typescript@5.1.6)(zod@3.22.4):
@@ -1136,20 +1067,6 @@ packages:
       - zod
     dev: false
 
-  /@latticexyz/recs@2.0.6(typescript@5.1.6)(zod@3.22.4):
-    resolution: {integrity: sha512-lHeOeTZNLlVPXjiLxTZ2BBVhXrmCU0RFCQoDbp3dpp+7Gf4NihTC7wctDoxlqbefe7DByfrBOLz0ehjtVtlYeg==}
-    dependencies:
-      '@latticexyz/schema-type': 2.0.6(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/utils': 2.0.6
-      mobx: 6.12.3
-      rxjs: 7.5.5
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
-    dev: false
-
   /@latticexyz/recs@2.0.9(typescript@5.1.6)(zod@3.22.4):
     resolution: {integrity: sha512-gBL7Akx9DtEaCTr/24GWwp3NE41uJf+gD4WU+cVkXKiy31nnyOkwon2EaXN3qPv+B0Qv7WRQAxZOW2mv7dnFtw==}
     dependencies:
@@ -1157,18 +1074,6 @@ packages:
       '@latticexyz/utils': 2.0.9
       mobx: 6.12.3
       rxjs: 7.5.5
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
-    dev: false
-
-  /@latticexyz/schema-type@2.0.6(typescript@5.1.6)(zod@3.22.4):
-    resolution: {integrity: sha512-2WiwWeMK6kb/sNESMe6ElAg4y0dW88IqiK8wNSyRgkHJ+YV3QrT/JwFsTOcVSRnaWmMOWsws+Czvmb8zlC3VSA==}
-    dependencies:
-      abitype: 1.0.0(typescript@5.1.6)(zod@3.22.4)
-      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -1242,25 +1147,6 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@latticexyz/store@2.0.6(typescript@5.1.6):
-    resolution: {integrity: sha512-Ln+DrDYVXM5FHXzm7SPH8SP1IPbZXWKd4RBOslxf/2TxWMk4J9uNxgm+E9rwcgkacmgmCH32nX5eI1n8++IHLw==}
-    dependencies:
-      '@arktype/util': 0.0.29
-      '@latticexyz/common': 2.0.6(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/config': 2.0.6(typescript@5.1.6)
-      '@latticexyz/protocol-parser': 2.0.6(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/schema-type': 2.0.6(typescript@5.1.6)(zod@3.22.4)
-      abitype: 1.0.0(typescript@5.1.6)(zod@3.22.4)
-      arktype: 1.0.29-alpha
-      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
-      zod: 3.22.4
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - typescript
-      - utf-8-validate
-    dev: false
-
   /@latticexyz/store@2.0.9(typescript@5.1.6):
     resolution: {integrity: sha512-VNwBtNICdYBrLwMI4655fhUQLzxdXwjxt6orGYd1wjWMsP6o95MqmittWf21TVdpvK1p+bJayYJByBtxOwc1ow==}
     dependencies:
@@ -1280,14 +1166,6 @@ packages:
       - supports-color
       - typescript
       - utf-8-validate
-    dev: false
-
-  /@latticexyz/utils@2.0.6:
-    resolution: {integrity: sha512-sb7Hyul+sZQtx7GanugPlEK7NTZux+C/sXIJgXizWO6j/d0ix1IylUz+lEAGLHvZsYV79gJS564szaHalkL4xA==}
-    dependencies:
-      mobx: 6.12.3
-      proxy-deep: 3.1.1
-      rxjs: 7.5.5
     dev: false
 
   /@latticexyz/utils@2.0.9:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,14 +48,14 @@ importers:
         specifier: ^12.0.1
         version: 12.0.1
       '@latticexyz/common':
-        specifier: 2.0.0-main-d3f0d32f
-        version: 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
+        specifier: 2.0.9
+        version: 2.0.9(typescript@5.1.6)(zod@3.22.4)
       '@latticexyz/protocol-parser':
-        specifier: 2.0.0-main-d3f0d32f
-        version: 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
+        specifier: 2.0.9
+        version: 2.0.9(typescript@5.1.6)(zod@3.22.4)
       '@latticexyz/store-sync':
-        specifier: 2.0.0-main-d3f0d32f
-        version: 2.0.0-main-d3f0d32f(react@18.2.0)(typescript@5.1.6)
+        specifier: 2.0.9
+        version: 2.0.9(react@18.3.1)(typescript@5.1.6)
       accepts:
         specifier: ^1.3.8
         version: 1.3.8
@@ -81,8 +81,8 @@ importers:
         specifier: ^1.12.4
         version: 1.13.3
       viem:
-        specifier: 1.14.0
-        version: 1.14.0(typescript@5.1.6)(zod@3.22.4)
+        specifier: 2.9.20
+        version: 2.9.20(typescript@5.1.6)(zod@3.22.4)
       zod:
         specifier: ^3.21.4
         version: 3.22.4
@@ -188,10 +188,6 @@ packages:
 
   /@adraffy/ens-normalize@1.10.0:
     resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
-    dev: false
-
-  /@adraffy/ens-normalize@1.9.4:
-    resolution: {integrity: sha512-UK0bHA7hh9cR39V+4gl2/NnBBjoXIxkuWAPCaY4X7fbH4L/azIi7ilWOCjMUYfpJgraLUAqkRi2BqrjME8Rynw==}
     dev: false
 
   /@arktype/util@0.0.29:
@@ -970,22 +966,6 @@ packages:
       - supports-color
     dev: false
 
-  /@latticexyz/block-logs-stream@2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4):
-    resolution: {integrity: sha512-hgDwKHkARmSYZqY6Pu8zeSuXNLfwzpAL7SNkQKkPU9xxovlfAL0uzMUFhvHXz2DBvkkr3zVL4a7086cH2ERTcg==}
-    dependencies:
-      '@latticexyz/common': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      abitype: 0.9.8(typescript@5.1.6)(zod@3.22.4)
-      debug: 4.3.4
-      rxjs: 7.5.5
-      viem: 1.14.0(typescript@5.1.6)(zod@3.22.4)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - typescript
-      - utf-8-validate
-      - zod
-    dev: false
-
   /@latticexyz/block-logs-stream@2.0.6(typescript@5.1.6)(zod@3.22.4):
     resolution: {integrity: sha512-kN0jNcVBrr9wblRnTFXnzQzSIG/151DAA1F1xv4+rA+yVjLgdgR3u51wKOwtPwjNPYyXWYULt3HBiCwkguUpfA==}
     dependencies:
@@ -1002,19 +982,17 @@ packages:
       - zod
     dev: false
 
-  /@latticexyz/common@2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4):
-    resolution: {integrity: sha512-y+rJvX0PDsYKNThAGgJR6IpngxKHiukD7Fowh9H+vnfrFLxoenswX+bIZ1eqqpiSHaRR5EIOlmQcKQbNA60Yxw==}
+  /@latticexyz/block-logs-stream@2.0.9(typescript@5.1.6)(zod@3.22.4):
+    resolution: {integrity: sha512-KCdrgrQ3Vsuwx1VHMHQO1JS/5UmtWxTWVw6LsKS6y6Oqy02v3Z2dZOfacZ9ZE4D59audWFz8BNZL1SW5j1PtPQ==}
     dependencies:
-      '@latticexyz/schema-type': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      '@solidity-parser/parser': 0.16.2
+      '@latticexyz/common': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      abitype: 1.0.0(typescript@5.1.6)(zod@3.22.4)
       debug: 4.3.4
-      execa: 7.2.0
-      p-queue: 7.4.1
-      p-retry: 5.1.2
-      prettier: 2.8.8
-      prettier-plugin-solidity: 1.1.3(prettier@2.8.8)
-      viem: 1.14.0(typescript@5.1.6)(zod@3.22.4)
+      rxjs: 7.5.5
+      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
     transitivePeerDependencies:
+      - '@aws-sdk/client-kms'
+      - asn1.js
       - bufferutil
       - supports-color
       - typescript
@@ -1042,21 +1020,32 @@ packages:
       - zod
     dev: false
 
-  /@latticexyz/config@2.0.0-main-d3f0d32f(typescript@5.1.6):
-    resolution: {integrity: sha512-MS0ive9kkT2yHwbuUgBWtltKYXiKxkTKNWD0o+jXRFPr9Lfn3QxrDdo1UdmCH3aNAMlW/mcEUdBY2hCQC7S7Ig==}
+  /@latticexyz/common@2.0.9(typescript@5.1.6)(zod@3.22.4):
+    resolution: {integrity: sha512-hI3gYt/4UhgsDXomTQXatDxe/WeINPQ3veZ4cZC1zWwpt5RviMJ33OTqY1p7rU4btqvsfY9NiZoMHmC8KaC34g==}
+    peerDependencies:
+      '@aws-sdk/client-kms': 3.x
+      asn1.js: 5.x
+    peerDependenciesMeta:
+      '@aws-sdk/client-kms':
+        optional: true
+      asn1.js:
+        optional: true
     dependencies:
-      '@latticexyz/common': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/schema-type': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      esbuild: 0.17.19
-      find-up: 6.3.0
-      viem: 1.14.0(typescript@5.1.6)(zod@3.22.4)
-      zod: 3.22.4
-      zod-validation-error: 1.5.0(zod@3.22.4)
+      '@latticexyz/schema-type': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@solidity-parser/parser': 0.16.2
+      debug: 4.3.4
+      execa: 7.2.0
+      p-queue: 7.4.1
+      p-retry: 5.1.2
+      prettier: 3.2.5
+      prettier-plugin-solidity: 1.3.1(prettier@3.2.5)
+      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
+      - zod
     dev: false
 
   /@latticexyz/config@2.0.6(typescript@5.1.6):
@@ -1076,19 +1065,23 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@latticexyz/protocol-parser@2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4):
-    resolution: {integrity: sha512-0xHvtLJo4OAWOTolA9cxOZHtPWvYgLUX1AA8ohrVADS7oOVxNb81OhceT8dtEqt2peSn1gLclCZNw0965fbNQA==}
+  /@latticexyz/config@2.0.9(typescript@5.1.6):
+    resolution: {integrity: sha512-iKvGHmI5Fk8J/C6tffJx1vMWhfIy03+7dk1kr1aGBsTC4BDajDoWNjmlXFxPgYtq8BxreuHVaR0W089+4nrKlQ==}
     dependencies:
-      '@latticexyz/common': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/schema-type': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      abitype: 0.9.8(typescript@5.1.6)(zod@3.22.4)
-      viem: 1.14.0(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/common': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/schema-type': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      esbuild: 0.17.19
+      find-up: 6.3.0
+      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
+      zod: 3.22.4
+      zod-validation-error: 1.5.0(zod@3.22.4)
     transitivePeerDependencies:
+      - '@aws-sdk/client-kms'
+      - asn1.js
       - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
-      - zod
     dev: false
 
   /@latticexyz/protocol-parser@2.0.6(typescript@5.1.6)(zod@3.22.4):
@@ -1107,15 +1100,37 @@ packages:
       - zod
     dev: false
 
-  /@latticexyz/recs@2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4):
-    resolution: {integrity: sha512-jqJsLc5SyN6K9GqFGCBqEwrT7BDHmbfE0SJJfbHf1OKuaEm915uWLUpiIEypfI3HrX3f2YtfDNaNvS8AsAcY7Q==}
+  /@latticexyz/protocol-parser@2.0.9(typescript@5.1.6)(zod@3.22.4):
+    resolution: {integrity: sha512-fIQJw8061DT/xKvaQxxGLXKPCZyyvKofg3g1E4/nfTPBKVMfbkTIzSjbjTbznVZ5Sefp3ng4RYA6t3s9v0/RPQ==}
     dependencies:
-      '@latticexyz/schema-type': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/utils': 2.0.0-main-d3f0d32f
-      mobx: 6.12.3
-      rxjs: 7.5.5
+      '@latticexyz/common': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/config': 2.0.9(typescript@5.1.6)
+      '@latticexyz/schema-type': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      abitype: 1.0.0(typescript@5.1.6)(zod@3.22.4)
+      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
     transitivePeerDependencies:
+      - '@aws-sdk/client-kms'
+      - asn1.js
       - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /@latticexyz/query@2.0.9(typescript@5.1.6)(zod@3.22.4):
+    resolution: {integrity: sha512-MVHJe83rjOd9K73zyWG8aNXdiPZeT0lIyjMILm07UBweqiLouVPxW3Aij980kPx4JUzZ6L34Lnovg7PbcoZKbw==}
+    dependencies:
+      '@latticexyz/common': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/config': 2.0.9(typescript@5.1.6)
+      '@latticexyz/schema-type': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/store': 2.0.9(typescript@5.1.6)
+      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
+    transitivePeerDependencies:
+      - '@aws-sdk/client-kms'
+      - asn1.js
+      - bufferutil
+      - supports-color
       - typescript
       - utf-8-validate
       - zod
@@ -1135,11 +1150,13 @@ packages:
       - zod
     dev: false
 
-  /@latticexyz/schema-type@2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4):
-    resolution: {integrity: sha512-wXlTgHtlcFIFz9a4iGi4Edvp70ZuGdMOH9s4qfJ/xx3P66v3OlVxA0zJumOTHkkUc3wNRHZT/5WkWe0DT9ZlcA==}
+  /@latticexyz/recs@2.0.9(typescript@5.1.6)(zod@3.22.4):
+    resolution: {integrity: sha512-gBL7Akx9DtEaCTr/24GWwp3NE41uJf+gD4WU+cVkXKiy31nnyOkwon2EaXN3qPv+B0Qv7WRQAxZOW2mv7dnFtw==}
     dependencies:
-      abitype: 0.9.8(typescript@5.1.6)(zod@3.22.4)
-      viem: 1.14.0(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/schema-type': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/utils': 2.0.9
+      mobx: 6.12.3
+      rxjs: 7.5.5
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -1159,30 +1176,46 @@ packages:
       - zod
     dev: false
 
-  /@latticexyz/store-sync@2.0.0-main-d3f0d32f(react@18.2.0)(typescript@5.1.6):
-    resolution: {integrity: sha512-P86Dtsh5X0E3Sg/u3iA4bbGp6DtbVHtYu4KvpkcJ6IIVmjcyncfsbX+PUzaFBY6kysf7Qo54DlZrpM1w47OO9g==}
+  /@latticexyz/schema-type@2.0.9(typescript@5.1.6)(zod@3.22.4):
+    resolution: {integrity: sha512-iynRKq5qgKJO9hCyIJn57sklLSmkjtxPKhcdx0uvGeaWh/SK9d+Yz383+NyLq85vaIRNcbkp3oE8YQjK0Exx3g==}
     dependencies:
-      '@latticexyz/block-logs-stream': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/common': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/protocol-parser': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/recs': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/schema-type': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/store': 2.0.0-main-d3f0d32f(typescript@5.1.6)
-      '@latticexyz/world': 2.0.0-main-d3f0d32f(typescript@5.1.6)
+      abitype: 1.0.0(typescript@5.1.6)(zod@3.22.4)
+      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /@latticexyz/store-sync@2.0.9(react@18.3.1)(typescript@5.1.6):
+    resolution: {integrity: sha512-Izzn0f/nM7kmlJBq4a7sDJIlTG4ke+gna7bzY5Bq6J5Hbnbvp2La4+LAgteWs77h4W/4dHMPZl7N1EtwNaWEFQ==}
+    dependencies:
+      '@latticexyz/block-logs-stream': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/common': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/config': 2.0.9(typescript@5.1.6)
+      '@latticexyz/protocol-parser': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/query': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/recs': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/schema-type': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/store': 2.0.9(typescript@5.1.6)
+      '@latticexyz/world': 2.0.9(typescript@5.1.6)
       '@trpc/client': 10.34.0(@trpc/server@10.34.0)
       '@trpc/server': 10.34.0
       change-case: 5.4.2
       debug: 4.3.4
-      drizzle-orm: 0.28.6(kysely@0.26.3)(postgres@3.3.5)(sql.js@1.9.0)
+      drizzle-orm: 0.28.6(kysely@0.26.3)(postgres@3.3.5)(sql.js@1.10.3)
+      fast-deep-equal: 3.1.3
       kysely: 0.26.3
       postgres: 3.3.5
       rxjs: 7.5.5
-      sql.js: 1.9.0
+      sql.js: 1.10.3
       superjson: 1.13.3
-      viem: 1.14.0(typescript@5.1.6)(zod@3.22.4)
+      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
       zod: 3.22.4
-      zustand: 4.4.7(react@18.2.0)
+      zustand: 4.5.2(react@18.3.1)
     transitivePeerDependencies:
+      - '@aws-sdk/client-kms'
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
       - '@libsql/client'
@@ -1194,6 +1227,7 @@ packages:
       - '@types/react'
       - '@types/sql.js'
       - '@vercel/postgres'
+      - asn1.js
       - better-sqlite3
       - bufferutil
       - bun-types
@@ -1203,22 +1237,6 @@ packages:
       - pg
       - react
       - sqlite3
-      - supports-color
-      - typescript
-      - utf-8-validate
-    dev: false
-
-  /@latticexyz/store@2.0.0-main-d3f0d32f(typescript@5.1.6):
-    resolution: {integrity: sha512-UAMLE1oiS3Y4dPIO2hbro3v9Utk/S+0tuzFER2fGgjT/qktW4jW5v452JOq8klmp7UO5Q9niVa3SG5+YapAxZw==}
-    dependencies:
-      '@latticexyz/common': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/config': 2.0.0-main-d3f0d32f(typescript@5.1.6)
-      '@latticexyz/schema-type': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      abitype: 0.9.8(typescript@5.1.6)(zod@3.22.4)
-      viem: 1.14.0(typescript@5.1.6)(zod@3.22.4)
-      zod: 3.22.4
-    transitivePeerDependencies:
-      - bufferutil
       - supports-color
       - typescript
       - utf-8-validate
@@ -1243,12 +1261,25 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@latticexyz/utils@2.0.0-main-d3f0d32f:
-    resolution: {integrity: sha512-0aLS9eHYAVEyhME9XNK+QZ5wxHVeCERvR4iy07I01JFpNeCQY4TjFu0qQFh5MdZ3iUpNrxOsB8AbxKmurk6AeQ==}
+  /@latticexyz/store@2.0.9(typescript@5.1.6):
+    resolution: {integrity: sha512-VNwBtNICdYBrLwMI4655fhUQLzxdXwjxt6orGYd1wjWMsP6o95MqmittWf21TVdpvK1p+bJayYJByBtxOwc1ow==}
     dependencies:
-      mobx: 6.12.3
-      proxy-deep: 3.1.1
-      rxjs: 7.5.5
+      '@arktype/util': 0.0.29
+      '@latticexyz/common': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/config': 2.0.9(typescript@5.1.6)
+      '@latticexyz/protocol-parser': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/schema-type': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      abitype: 1.0.0(typescript@5.1.6)(zod@3.22.4)
+      arktype: 1.0.29-alpha
+      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - '@aws-sdk/client-kms'
+      - asn1.js
+      - bufferutil
+      - supports-color
+      - typescript
+      - utf-8-validate
     dev: false
 
   /@latticexyz/utils@2.0.6:
@@ -1259,17 +1290,30 @@ packages:
       rxjs: 7.5.5
     dev: false
 
-  /@latticexyz/world@2.0.0-main-d3f0d32f(typescript@5.1.6):
-    resolution: {integrity: sha512-t/+UYvJzrkkg6D9JTVDUSkWKp0zNyzwWO0qRlHkxB1q4G4dgKUJgPbhwnRQYi50aLH7oXSo/ydUqyLrQB2xbnw==}
+  /@latticexyz/utils@2.0.9:
+    resolution: {integrity: sha512-MZyoMWz6TFaKHfYRhMFi4L/oqYpVo/iBq/taJy6zwKy44tmHxtx2jHfffLNaGIqEXwvjevCCbvN3Af5OoAnXBA==}
     dependencies:
-      '@latticexyz/common': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/config': 2.0.0-main-d3f0d32f(typescript@5.1.6)
-      '@latticexyz/schema-type': 2.0.0-main-d3f0d32f(typescript@5.1.6)(zod@3.22.4)
-      '@latticexyz/store': 2.0.0-main-d3f0d32f(typescript@5.1.6)
-      abitype: 0.9.8(typescript@5.1.6)(zod@3.22.4)
-      viem: 1.14.0(typescript@5.1.6)(zod@3.22.4)
+      mobx: 6.12.3
+      proxy-deep: 3.1.1
+      rxjs: 7.5.5
+    dev: false
+
+  /@latticexyz/world@2.0.9(typescript@5.1.6):
+    resolution: {integrity: sha512-KLNiwa+2CJRyBG44Z65jI9593ynDEBEYa2QB7qtCQpseMTQipXugA/fDnszJZkwXZkNJz0HwYvB2R7jg+WQJxg==}
+    dependencies:
+      '@arktype/util': 0.0.29
+      '@latticexyz/common': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/config': 2.0.9(typescript@5.1.6)
+      '@latticexyz/protocol-parser': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/schema-type': 2.0.9(typescript@5.1.6)(zod@3.22.4)
+      '@latticexyz/store': 2.0.9(typescript@5.1.6)
+      abitype: 1.0.0(typescript@5.1.6)(zod@3.22.4)
+      arktype: 1.0.29-alpha
+      viem: 2.9.20(typescript@5.1.6)(zod@3.22.4)
       zod: 3.22.4
     transitivePeerDependencies:
+      - '@aws-sdk/client-kms'
+      - asn1.js
       - bufferutil
       - supports-color
       - typescript
@@ -2135,6 +2179,7 @@ packages:
     resolution: {integrity: sha512-IGRJfoNX10N/PfrReRZ1br/7SQ+2vF/tK3KXNwzXz82D32z5dMQEoOlFew18nLSN+vMNcLY4GrKfzwi/yWI8/w==}
     dependencies:
       undici-types: 5.26.5
+    dev: true
 
   /@types/normalize-package-data@2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -2170,12 +2215,6 @@ packages:
       '@types/mime': 3.0.4
       '@types/node': 18.19.7
     dev: true
-
-  /@types/ws@8.5.10:
-    resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
-    dependencies:
-      '@types/node': 18.19.7
-    dev: false
 
   /@typescript-eslint/eslint-plugin@5.46.1(@typescript-eslint/parser@5.46.1)(eslint@8.29.0)(typescript@5.1.6):
     resolution: {integrity: sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==}
@@ -2555,21 +2594,6 @@ packages:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dev: true
-
-  /abitype@0.9.8(typescript@5.1.6)(zod@3.22.4):
-    resolution: {integrity: sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3 >=3.19.1
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
-    dependencies:
-      typescript: 5.1.6
-      zod: 3.22.4
-    dev: false
 
   /abitype@1.0.0(typescript@5.1.6)(zod@3.22.4):
     resolution: {integrity: sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==}
@@ -3526,7 +3550,7 @@ packages:
     resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
     engines: {node: '>=12'}
 
-  /drizzle-orm@0.28.6(kysely@0.26.3)(postgres@3.3.5)(sql.js@1.9.0):
+  /drizzle-orm@0.28.6(kysely@0.26.3)(postgres@3.3.5)(sql.js@1.10.3):
     resolution: {integrity: sha512-yBe+F9htrlYER7uXgDJUQsTHFoIrI5yMm5A0bg0GiZ/kY5jNXTWoEy4KQtg35cE27sw1VbgzoMWHAgCckUUUww==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
@@ -3590,7 +3614,7 @@ packages:
     dependencies:
       kysely: 0.26.3
       postgres: 3.3.5
-      sql.js: 1.9.0
+      sql.js: 1.10.3
     dev: false
 
   /duplexer@0.1.2:
@@ -3905,7 +3929,7 @@ packages:
       lodash.merge: 4.6.2
       minimatch: 3.1.2
       natural-compare: 1.4.0
-      optionator: 0.9.3
+      optionator: 0.9.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
     transitivePeerDependencies:
@@ -4038,7 +4062,6 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-    dev: true
 
   /fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
@@ -4905,14 +4928,6 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /isomorphic-ws@5.0.0(ws@8.13.0):
-    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
-    peerDependencies:
-      ws: '*'
-    dependencies:
-      ws: 8.13.0
-    dev: false
 
   /isows@1.0.3(ws@8.13.0):
     resolution: {integrity: sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==}
@@ -6123,6 +6138,18 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+    dev: true
+
   /ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
@@ -6518,18 +6545,6 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier-plugin-solidity@1.1.3(prettier@2.8.8):
-    resolution: {integrity: sha512-fQ9yucPi2sBbA2U2Xjh6m4isUTJ7S7QLc/XDDsktqqxYfTwdYKJ0EnnywXHwCGAaYbQNK+HIYPL1OemxuMsgeg==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      prettier: '>=2.3.0 || >=3.0.0-alpha.0'
-    dependencies:
-      '@solidity-parser/parser': 0.16.2
-      prettier: 2.8.8
-      semver: 7.5.4
-      solidity-comments-extractor: 0.0.7
-    dev: false
-
   /prettier-plugin-solidity@1.3.1(prettier@3.2.5):
     resolution: {integrity: sha512-MN4OP5I2gHAzHZG1wcuJl0FsLS3c4Cc5494bbg+6oQWBPuEamjwDvmGfFMZ6NFzsh3Efd9UUxeT7ImgjNH4ozA==}
     engines: {node: '>=16'}
@@ -6540,12 +6555,6 @@ packages:
       prettier: 3.2.5
       semver: 7.6.0
       solidity-comments-extractor: 0.0.8
-    dev: false
-
-  /prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
     dev: false
 
   /prettier@3.2.5:
@@ -6639,8 +6648,8 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
-  /react@18.2.0:
-    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+  /react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
@@ -6952,6 +6961,7 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: true
 
   /semver@7.6.0:
     resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
@@ -7085,10 +7095,6 @@ packages:
       smart-buffer: 4.2.0
     dev: true
 
-  /solidity-comments-extractor@0.0.7:
-    resolution: {integrity: sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==}
-    dev: false
-
   /solidity-comments-extractor@0.0.8:
     resolution: {integrity: sha512-htM7Vn6LhHreR+EglVMd2s+sZhcXAirB1Zlyrv5zBuTxieCvjfnRpd7iZk75m/u6NOlEyQ94C6TWbBn2cY7w8g==}
     dev: false
@@ -7166,8 +7172,8 @@ packages:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: true
 
-  /sql.js@1.9.0:
-    resolution: {integrity: sha512-+QMN8NU5KJxofT+lEaSLYdhh+Pdq7ZYS6X5bSbpmD+4SKFf+qBmr+coKT07LZ+keUNh1sf3Nz9dQwD8WNI2i/Q==}
+  /sql.js@1.10.3:
+    resolution: {integrity: sha512-H46aWtQkdyjZwFQgraUruy5h/DyJBbAK3EA/WEMqiqF6PGPfKBSKBj/er3dVyYqVIoYfRf5TFM/loEjtQIrqJg==}
     dev: false
 
   /ssri@10.0.5:
@@ -7754,6 +7760,7 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
 
   /unique-filename@3.0.0:
     resolution: {integrity: sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==}
@@ -7789,12 +7796,12 @@ packages:
       punycode: 2.3.1
     dev: true
 
-  /use-sync-external-store@1.2.0(react@18.2.0):
+  /use-sync-external-store@1.2.0(react@18.3.1):
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      react: 18.2.0
+      react: 18.3.1
     dev: false
 
   /util-deprecate@1.0.2:
@@ -7833,30 +7840,6 @@ packages:
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-    dev: false
-
-  /viem@1.14.0(typescript@5.1.6)(zod@3.22.4):
-    resolution: {integrity: sha512-4d+4/H3lnbkSAbrpQ15i1nBA7hne06joLFy3L3m0ZpMc+g+Zr3D4nuSTyeiqbHAYs9m2P9Kjap0HlyGkehasgg==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@adraffy/ens-normalize': 1.9.4
-      '@noble/curves': 1.2.0
-      '@noble/hashes': 1.3.2
-      '@scure/bip32': 1.3.2
-      '@scure/bip39': 1.2.1
-      '@types/ws': 8.5.10
-      abitype: 0.9.8(typescript@5.1.6)(zod@3.22.4)
-      isomorphic-ws: 5.0.0(ws@8.13.0)
-      typescript: 5.1.6
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
     dev: false
 
   /viem@2.9.20(typescript@5.1.6)(zod@3.22.4):
@@ -8070,6 +8053,11 @@ packages:
       string-width: 4.2.3
     dev: true
 
+  /word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: true
@@ -8255,12 +8243,12 @@ packages:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
     dev: false
 
-  /zustand@4.4.7(react@18.2.0):
-    resolution: {integrity: sha512-QFJWJMdlETcI69paJwhSMJz7PPWjVP8Sjhclxmxmxv/RYI7ZOvR5BHX+ktH0we9gTWQMxcne8q1OY8xxz604gw==}
+  /zustand@4.5.2(react@18.3.1):
+    resolution: {integrity: sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
       '@types/react': '>=16.8'
-      immer: '>=9.0'
+      immer: '>=9.0.6'
       react: '>=16.8'
     peerDependenciesMeta:
       '@types/react':
@@ -8270,6 +8258,6 @@ packages:
       react:
         optional: true
     dependencies:
-      react: 18.2.0
-      use-sync-external-store: 1.2.0(react@18.2.0)
+      react: 18.3.1
+      use-sync-external-store: 1.2.0(react@18.3.1)
     dev: false


### PR DESCRIPTION
### pg-indexer-reader

1. Fix table name + schema format from:
```ts
const dbTableName = snakeCase(name);
const schema = `${address}__${namespace}`;
```
to:
```ts
const dbTableName = `${snakeCase(namespace)}__${snakeCase(name)}`;
const schema = address;
```

2. Upgrade MUD to 2.0.9, viem to 2.9.20;
3. Small patches mirrored from latest commits to MUD store-indexer package.

### sync-stack

1. Upgrade MUD to 2.0.9